### PR TITLE
Changed Private Key Generation Method

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -3,7 +3,7 @@ name: Build and release
 on:
   push:
     tags:
-      - '*'
+      - 'v*.*.*'
 
 jobs:
   build:

--- a/cmd/services/rootCaService.go
+++ b/cmd/services/rootCaService.go
@@ -31,9 +31,10 @@ func CreateRootCa(CaDir string) (string, string, string) {
 		log.Debug("Root CA dir already exists, skipping.")
 	}
 
-	// Create rootCA key with openssl
+	// Create rootCA key
 	rootCaKeyFile := rootCaDir + "/rootCA.key"
 	if _, err := os.Stat(rootCaKeyFile); os.IsNotExist(err) {
+		log.Debug("Root CA Key is being created.")
 		caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
 		if err != nil {
 			log.Error(err)
@@ -53,6 +54,7 @@ func CreateRootCa(CaDir string) (string, string, string) {
 		if err != nil {
 			panic(err)
 		}
+		log.Debug("Root CA Key generated at ", rootCaKeyFile)
 	} else {
 		log.Debug("Root CA Key already exists, skipping.")
 	}


### PR DESCRIPTION
Private keys now generated with native golang library instead of openssl system command.
Generating the key with openssl was causing a problem on old openssl versions.